### PR TITLE
Fix: improved rendering for custom descriptions in activity log 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.idea
 /.vscode
 /.env
+composer.lock

--- a/src/Controllers/ActivityController.php
+++ b/src/Controllers/ActivityController.php
@@ -126,8 +126,11 @@ class ActivityController extends Controller
                 return $record->id;
             })
             ->addColumn('description', function ($record) {
-                return self::stateToText($record->description);
+                return in_array(strtolower($record->description), ['created', 'updated', 'deleted'])
+                    ? self::stateToText($record->description)
+                    : $record->description;
             })
+
             ->addColumn('subject_type', function ($record) {
                 $subjectTypeShort = $record->subject_type ? explode('\\', $record->subject_type) : [];
 

--- a/src/resources/views/index.blade.php
+++ b/src/resources/views/index.blade.php
@@ -3,6 +3,7 @@
     <!-- Styles Bootstrap 5.2 -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.11.3/css/dataTables.bootstrap5.min.css">
+
     <style>
         :root {
             --primary-color: #00a69f !important;
@@ -374,8 +375,9 @@
             function renderDescription(data) {
                 let cssClass = '';
                 if (data === 'Created') cssClass = 'bg-created';
-                if (data === 'Updated') cssClass = 'bg-updated';
-                if (data === 'Deleted') cssClass = 'bg-deleted';
+                else if (data === 'Updated') cssClass = 'bg-updated';
+                else if (data === 'Deleted') cssClass = 'bg-deleted';
+                else cssClass = 'bg-secondary';
                 return `<span class="badge ${cssClass}">${data}</span>`;
             }
 


### PR DESCRIPTION
- Updated **ActivityController** to handle customized log descriptions directly  
- Updated **index.blade.php** to include **bg-secondary** badge color for direct description handling  
- Updated **.gitignore** to exclude the **composer.lock** file

